### PR TITLE
(Settings): #015 Add relationship feature to settings component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "seatable-plugin-template",
+  "name": "seatable-org-chart-plugin",
   "version": "0.1.2",
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "seatable-org-chart-plugin",
+  "name": "seatable-plugin-org-chart",
   "version": "0.1.2",
   "private": true,
   "dependencies": {

--- a/src/CustomPlugin/index.tsx
+++ b/src/CustomPlugin/index.tsx
@@ -45,6 +45,10 @@ const CustomPlugin: React.FC<ICustomPluginProps> = ({
         style={{
           color: '#ff6666',
         }}>{`Active View: ${appActiveState?.activeTableView?.name}`}</div>
+      <div
+        style={{
+          color: '#ff6666',
+        }}>{`Active Relationship: ${appActiveState?.activeRelationship?.name}`}</div>
     </div>
     <div
       style={{

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -244,7 +244,7 @@ const App: React.FC<IAppProps> = (props) => {
     setAppActiveState((prevState) => ({
       ...prevState,
       activePresetIdx: _activePresetIdx,
-      activeRelationship: updatedPresets[activePresetIdx].settings?.relationship
+      activeRelationship: updatedPresets[_activePresetIdx].settings?.relationship
     }));
     setPluginPresets(updatedPresets);
     setPluginDataStore(pluginDataStore);
@@ -281,6 +281,7 @@ const App: React.FC<IAppProps> = (props) => {
       activeTableName: table.name,
       activeTableView: view,
       activeViewRows: window.dtableSDK.getViewRows(view, table),
+      activeRelationship: pluginPresets[0].settings?.relationship
     };
 
     setAppActiveState(newPresetActiveState);

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -42,6 +42,7 @@ import {
   findPresetName,
   getActiveStateSafeGuard,
   getActiveTableAndActiveView,
+  getDefaultLinkColumn,
   getPluginDataStore,
   isMobile,
   parsePluginDataToActiveState,
@@ -65,7 +66,7 @@ const App: React.FC<IAppProps> = (props) => {
   // For better understanding read the comments in the AppActiveState interface
   const [appActiveState, setAppActiveState] = useState<AppActiveState>(INITIAL_CURRENT_STATE);
   // Destructure properties from the app's active state for easier access
-  const { activeTable, activePresetId, activePresetIdx, activeViewRows, activeTableView } =
+  const { activeTable, activePresetId, activePresetIdx, activeViewRows } =
     appActiveState;
   const { collaborators } = window.app.state;
 
@@ -200,6 +201,7 @@ const App: React.FC<IAppProps> = (props) => {
         allTables.find((table) => table._id === _activeTableId)?.views || [];
 
       updatedActiveState = {
+        activeRelationship: activePreset?.settings?.relationship,
         activeTable: allTables.find((table) => table._id === _activeTableId) || activeTable,
         activeTableName: _activeTableName,
         activeTableView:
@@ -242,6 +244,7 @@ const App: React.FC<IAppProps> = (props) => {
     setAppActiveState((prevState) => ({
       ...prevState,
       activePresetIdx: _activePresetIdx,
+      activeRelationship: updatedPresets[activePresetIdx].settings?.relationship
     }));
     setPluginPresets(updatedPresets);
     setPluginDataStore(pluginDataStore);
@@ -319,6 +322,7 @@ const App: React.FC<IAppProps> = (props) => {
           activeTableName: _activeTable.name,
           activeTableView: _activeTable.views[0],
           activeViewRows: _activeViewRows,
+          activeRelationship: getDefaultLinkColumn(_activeTable)
         }));
 
         updatedPluginPresets = pluginPresets.map((preset) =>
@@ -327,6 +331,7 @@ const App: React.FC<IAppProps> = (props) => {
                 ...preset,
                 settings: {
                   ...preset.settings,
+                  relationship: getDefaultLinkColumn(_activeTable),
                   selectedTable: { value: _activeTable._id, label: _activeTable.name },
                   selectedView: {
                     value: _activeTable.views[0]._id,
@@ -391,11 +396,8 @@ const App: React.FC<IAppProps> = (props) => {
   const onInsertRow = (table: Table, view: TableView, rowData: any) => {
     let columns = window.dtableSDK.getColumns(table);
     let newRowData: { [key: string]: any } = {};
-    console.log('columns', columns);
     for (let key in rowData) {
-      console.log('key', key);
       let column = columns.find((column: TableColumn) => column.name === key);
-      console.log('column.type', column.type);
       if (!column) {
         continue;
       }
@@ -489,6 +491,9 @@ const App: React.FC<IAppProps> = (props) => {
             appActiveState={appActiveState}
             activeTableViews={activeTableViews}
             pluginPresets={pluginPresets}
+            activePresetIdx={activePresetIdx}
+            pluginDataStore={pluginDataStore}
+            updatePresets={updatePresets}
             onTableOrViewChange={onTableOrViewChange}
             onToggleSettings={toggleSettings}
           />

--- a/src/components/PluginPresets/index.tsx
+++ b/src/components/PluginPresets/index.tsx
@@ -180,6 +180,7 @@ const PluginPresets: React.FC<IPresetsProps> = ({
       activeTable: _activeTableAndView.table,
       activeTableName: newPresetsArray[_activePresetIdx]?.settings?.selectedTable?.label!,
       activeTableView: _activeTableAndView.view,
+      activeRelationship: newPresetsArray[_activePresetIdx]?.settings?.relationship
     };
 
     onSelectPreset(_id, newPresetActiveState);

--- a/src/components/PluginSettings/index.tsx
+++ b/src/components/PluginSettings/index.tsx
@@ -135,7 +135,7 @@ const PluginSettings: React.FC<IPluginSettingsProps> = ({
           {/* custom settings */}
           <div className={styles.settings_dropdowns_noborder}>
             <div className='mt-3'>
-              <p className="d-inline-block mb-2">Relationship</p>
+              <p className="d-inline-block mb-2">{intl.get('relationship').d(`${d.relationship}/`)}</p>
               {/* Toggle relationship value */}
               <DtableSelect
                 value={relationshipSelectedOption}

--- a/src/locale/lang/de.json
+++ b/src/locale/lang/de.json
@@ -6,5 +6,6 @@
   "preset_rename": "Umbenennen",
   "preset_duplicate": "Duplizieren",
   "preset_delete": "Löschen",
-  "preset_warn_exist": "Bitte wählen Sie einen einzigartigen Namen"
+  "preset_warn_exist": "Bitte wählen Sie einen einzigartigen Namen",
+  "relationship": "Beziehung"
 }

--- a/src/locale/lang/en.json
+++ b/src/locale/lang/en.json
@@ -6,5 +6,6 @@
   "preset_rename": "Rename",
   "preset_duplicate": "Duplicate",
   "preset_delete": "Delete",
-  "preset_warn_exist": "Please enter a unique preset name"
+  "preset_warn_exist": "Please enter a unique preset name",
+  "relationship": "Relationship"
 }

--- a/src/locale/lang/es.json
+++ b/src/locale/lang/es.json
@@ -6,5 +6,6 @@
   "preset_rename": "Renombrar",
   "preset_duplicate": "Duplicado",
   "preset_delete": "Borrar",
-  "preset_warn_exist": "Introduzca un nombre único para la preajuste"
+  "preset_warn_exist": "Introduzca un nombre único para la preajuste",
+  "relationship": "relación"
 }

--- a/src/locale/lang/fr.json
+++ b/src/locale/lang/fr.json
@@ -6,5 +6,6 @@
   "preset_rename": "Renommer",
   "preset_duplicate": "Dupliquer",
   "preset_delete": "Supprimmer",
-  "preset_warn_exist": "Veuillez saisir un nom de préréglage unique"
+  "preset_warn_exist": "Veuillez saisir un nom de préréglage unique",
+  "relationship": "Relation"
 }

--- a/src/locale/lang/pt.json
+++ b/src/locale/lang/pt.json
@@ -6,5 +6,6 @@
   "preset_rename": "Renomear",
   "preset_duplicate": "Duplicado",
   "preset_delete": "Excluir",
-  "preset_warn_exist": "Introduza um nome de predefinição único"
+  "preset_warn_exist": "Introduza um nome de predefinição único",
+  "relationship": "Relação"
 }

--- a/src/locale/lang/ru.json
+++ b/src/locale/lang/ru.json
@@ -6,5 +6,6 @@
   "preset_rename": "переименовать",
   "preset_duplicate": "дубликат",
   "preset_delete": "удалить",
-  "preset_warn_exist": "Пожалуйста, введите уникальное имя предустановки"
+  "preset_warn_exist": "Пожалуйста, введите уникальное имя предустановки",
+  "relationship": "Отношение"
 }

--- a/src/locale/lang/zh_CN.json
+++ b/src/locale/lang/zh_CN.json
@@ -6,5 +6,6 @@
   "preset_rename": "重命名预置",
   "preset_duplicate": "复制预置",
   "preset_delete": "删除预设",
-  "preset_warn_exist": "请输入唯一的预设名称"
+  "preset_warn_exist": "请输入唯一的预设名称",
+  "relationship": "關係"
 }

--- a/src/plugin-config/info.json
+++ b/src/plugin-config/info.json
@@ -1,7 +1,7 @@
 {
-  "name": "plugin-template",
+  "name": "org-chart-plugin",
   "version": "0.9.0",
   "display_type": "overlay",
-  "display_name": "Plugin template",
+  "display_name": "Org Chart Plugin",
   "description": "Design your own SeaTable plugin."
 }

--- a/src/plugin-config/info.json
+++ b/src/plugin-config/info.json
@@ -1,5 +1,5 @@
 {
-  "name": "org-chart-plugin",
+  "name": "plugin-org-chart",
   "version": "0.9.0",
   "display_type": "overlay",
   "display_name": "Org Chart Plugin",

--- a/src/styles/PluginSettings.module.scss
+++ b/src/styles/PluginSettings.module.scss
@@ -33,6 +33,10 @@
   &_dropdowns {
     padding-bottom: 20px;
     border-bottom: 1px solid $borderColor;
+
+    &_noborder {
+      border: none;
+    }
   }
 
   p {

--- a/src/utils/Interfaces/App.interface.ts
+++ b/src/utils/Interfaces/App.interface.ts
@@ -1,5 +1,5 @@
 import { PresetsArray } from './PluginPresets/Presets.interface';
-import { Table, TableRow, TableView } from './Table.interface';
+import { Table, TableColumn, TableRow, TableView } from './Table.interface';
 
 export interface IAppProps {
   isDevelopment?: boolean;
@@ -32,6 +32,7 @@ export interface AppActiveState {
   activeTableName: string; // Holds the name of the active table // TO REMOVE
   activeTableView: TableView | null; // Represents the currently active table view in the app
   activeViewRows?: TableRow[]; // Represents the currently active view rows in the app
+  activeRelationship?: TableColumn
 }
 
 export interface IPluginDataStore

--- a/src/utils/Interfaces/PluginPresets/Presets.interface.ts
+++ b/src/utils/Interfaces/PluginPresets/Presets.interface.ts
@@ -1,7 +1,7 @@
 import { PLUGIN_NAME } from '../../constants';
 import { AppActiveState, IPluginDataStore } from '../App.interface';
 import { SelectOption } from '../PluginSettings.interface';
-import { TableArray } from '../Table.interface';
+import { TableArray, TableColumn } from '../Table.interface';
 
 export interface IPresetsProps {
   pluginPresets: PresetsArray;
@@ -38,6 +38,7 @@ export interface PresetSettings {
   shown_title_name?: string | undefined;
   selectedTable?: SelectOption;
   selectedView?: SelectOption;
+  relationship?: TableColumn;
 }
 
 export type PresetsArray = IPresetInfo[];

--- a/src/utils/Interfaces/PluginSettings.interface.ts
+++ b/src/utils/Interfaces/PluginSettings.interface.ts
@@ -1,5 +1,5 @@
 import { SettingsOption } from '../types';
-import { AppActiveState } from './App.interface';
+import { AppActiveState, IPluginDataStore } from './App.interface';
 import { PresetSettings, PresetsArray } from './PluginPresets/Presets.interface';
 import { TableArray, TableViewArray } from './Table.interface';
 
@@ -11,6 +11,9 @@ interface IPluginSettingsProps {
   onTableOrViewChange: (type: SettingsOption, option: SelectOption) => void;
   onToggleSettings: () => void;
   isShowSettings: boolean;
+  activePresetIdx: number,
+  pluginDataStore: IPluginDataStore,
+  updatePresets: (_activePresetIdx: number, updatedPresets: PresetsArray, pluginDataStore: IPluginDataStore, activePresetId: string, callBack?: any) => void;
 }
 
 interface SelectOption {

--- a/src/utils/constants/index.ts
+++ b/src/utils/constants/index.ts
@@ -10,7 +10,7 @@ const POSSIBLE = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz
 
 const PLUGIN_NAME = info.name
   .replace(/-([a-z])/g, (_, match) => ' ' + match.toUpperCase())
-  .replace(/^./, (str) => str.toUpperCase());
+  .replace(/^./, (str) => str.toUpperCase()).replace('Plugin', '');
 const PLUGIN_ID = `${info.name}-component`;
 
 // Table and Preset Defaults

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -5,6 +5,7 @@ import {
   IActiveTableAndView,
   Table,
   TableArray,
+  TableColumn,
   TableRow,
   TableView,
 } from './Interfaces/Table.interface';
@@ -239,6 +240,7 @@ export const parsePluginDataToActiveState = (
   let tableView = table.views.find(
     (v) => v._id === pluginPresets[idx].settings?.selectedView?.value
   )!;
+  let relationship = pluginPresets[idx].settings?.relationship || getDefaultLinkColumn(table);
 
   // Create the appActiveState object with the extracted data
   const appActiveState = {
@@ -247,6 +249,7 @@ export const parsePluginDataToActiveState = (
     activeTable: table,
     activeTableName: tableName,
     activeTableView: tableView,
+    activeRelationship: relationship
   };
 
   // Return the active state object
@@ -281,6 +284,7 @@ export const getActiveStateSafeGuard = (
     activePresetId: (pluginPresets[0] && pluginPresets[0]._id) || '0000', // '0000' as Safe guard if there are no presets
     activePresetIdx: 0,
     activeViewRows: activeViewRows,
+    activeRelationship: getDefaultLinkColumn(activeTableAndView?.table)
   };
 
   // Return the active state object considering presets or default values
@@ -348,6 +352,7 @@ export const createDefaultPluginDataStore = (
   const _presetSettings: PresetSettings = {
     selectedTable: { value: activeTable._id, label: activeTable.name },
     selectedView: { value: activeTable.views[0]._id, label: activeTable.views[0].name },
+    relationship: getDefaultLinkColumn(activeTable)
   };
 
   // Importing the default settings from the constants file and updating the presets array with the Default Settings
@@ -382,6 +387,7 @@ export const createDefaultPresetSettings = (allTables: TableArray) => {
     shown_title_name: 'Title',
     selectedTable: tableInfo,
     selectedView: viewInfo,
+    relationship: getDefaultLinkColumn(allTables[0])
   };
 };
 
@@ -391,4 +397,8 @@ export const findPresetName = (presets: PresetsArray, presetId: string) => {
 
 export const isMobile = () => {
   return window.innerWidth <= 800;
+};
+
+export const getDefaultLinkColumn = (table: Table) => {
+  return table.columns.filter((c:TableColumn ) => c.type === 'link')[0];
 };


### PR DESCRIPTION
Issue #15 
- Add relationship dropdown to settings
- If a new preset is created, by default, the relationship is set to the first link column (or null if no link column)
- Relationship is dynamic to each preset
- If the table of a preset is changed, by default, the relationship is set to the first link column of said table (or null if no link column)

https://www.loom.com/share/8807aad8ee2f463293665ca02353186c?sid=e416dd67-babe-4781-9267-fcddc9c18a73
